### PR TITLE
Split Broker into Broadcast and Standart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ pip install taskiq-redis
 # Usage
 
 Let's see the example with the redis broker and redis async result:
+
 ```python
 import asyncio
 
-from taskiq_redis.redis_broker import RedisBroker
+from taskiq_redis.redis_broker import ListQueueBroker
 from taskiq_redis.redis_backend import RedisAsyncResultBackend
-
 
 redis_async_result = RedisAsyncResultBackend(
     redis_url="redis://localhost:6379",
 )
 
-# Or you can use BroadcastRedisBroker if you need broadcasting
-broker = RedisBroker(
+# Or you can use PubSubBroker if you need broadcasting
+broker = ListQueueBroker(
     url="redis://localhost:6379",
     result_backend=redis_async_result,
 )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ redis_async_result = RedisAsyncResultBackend(
     redis_url="redis://localhost:6379",
 )
 
+# Or you can use BroadcastRedisBroker if you need broadcasting
 broker = RedisBroker(
     url="redis://localhost:6379",
     result_backend=redis_async_result,

--- a/taskiq_redis/__init__.py
+++ b/taskiq_redis/__init__.py
@@ -1,5 +1,5 @@
 """Package for redis integration."""
 from taskiq_redis.redis_backend import RedisAsyncResultBackend
-from taskiq_redis.redis_broker import RedisBroker
+from taskiq_redis.redis_broker import ListQueueBroker
 
-__all__ = ["RedisAsyncResultBackend", "RedisBroker"]
+__all__ = ["RedisAsyncResultBackend", "ListQueueBroker"]

--- a/taskiq_redis/redis_broker.py
+++ b/taskiq_redis/redis_broker.py
@@ -86,8 +86,8 @@ class BaseRedisBroker(AsyncBroker):
         yield  # type: ignore
 
 
-class BroadcastRedisBroker(BaseRedisBroker):
-    """Broker that works with Redis and broadcasts a task to all workers."""
+class PubSubBroker(BaseRedisBroker):
+    """Broker that works with Redis and broadcasts tasks to all workers."""
 
     async def kick(self, message: BrokerMessage) -> None:  # noqa: D102
         async with Redis(connection_pool=self.connection_pool) as redis_conn:
@@ -103,8 +103,8 @@ class BroadcastRedisBroker(BaseRedisBroker):
                 yield message["data"]
 
 
-class RedisBroker(BaseRedisBroker):
-    """Broker that works with Redis."""
+class ListQueueBroker(BaseRedisBroker):
+    """Broker that works with Redis and distributes tasks between workers."""
 
     async def kick(self, message: BrokerMessage) -> None:  # noqa: D102
         async with Redis(connection_pool=self.connection_pool) as redis_conn:


### PR DESCRIPTION
To solve [this issue](https://github.com/taskiq-python/taskiq-redis/issues/11), I suggest you use a standard List instead of PubSub. This allows you to use BRPOP to receive one message per worker. 
