### PR TITLE
Add super.shutdown() call in redis brokers

### DIFF
--- a/taskiq_redis/redis_broker.py
+++ b/taskiq_redis/redis_broker.py
@@ -49,6 +49,7 @@ class BaseRedisBroker(AsyncBroker):
 
     async def shutdown(self) -> None:
         """Closes redis connection pool."""
+        await super().shutdown()
         await self.connection_pool.disconnect()
 
     async def listen(self) -> AsyncGenerator[BrokerMessage, None]:


### PR DESCRIPTION
Closes https://github.com/taskiq-python/taskiq-redis/issues/29.