### PR TITLE
Use blocking connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Brokers parameters:
 * `result_backend` - custom result backend.
 * `queue_name` - name of the pub/sub channel in redis.
 * `max_connection_pool_size` - maximum number of connections in pool.
+* Any other keyword arguments are passed to `redis.asyncio.BlockingConnectionPool`.
+  Notably, you can use `timeout` to set custom timeout in seconds for reconnects
+  (or set it to `None` to try reconnects indefinitely).
 
 ## RedisAsyncResultBackend configuration
 
@@ -79,6 +82,9 @@ RedisAsyncResultBackend parameters:
 * `keep_results` - flag to not remove results from Redis after reading.
 * `result_ex_time` - expire time in seconds (by default - not specified)
 * `result_px_time` - expire time in milliseconds (by default - not specified)
+* Any other keyword arguments are passed to `redis.asyncio.BlockingConnectionPool`.
+  Notably, you can use `timeout` to set custom timeout in seconds for reconnects
+  (or set it to `None` to try reconnects indefinitely).
 > IMPORTANT: **It is highly recommended to use expire time ​​in RedisAsyncResultBackend**
 > If you want to add expiration, either `result_ex_time` or `result_px_time` must be set.
 >```python

--- a/taskiq_redis/redis_broker.py
+++ b/taskiq_redis/redis_broker.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from typing import Any, AsyncGenerator, Callable, Optional, TypeVar
 
-from redis.asyncio import ConnectionPool, Redis
+from redis.asyncio import BlockingConnectionPool, ConnectionPool, Redis
 from taskiq.abc.broker import AsyncBroker
 from taskiq.abc.result_backend import AsyncResultBackend
 from taskiq.message import BrokerMessage
@@ -31,14 +31,16 @@ class BaseRedisBroker(AsyncBroker):
         :param result_backend: custom result backend.
         :param queue_name: name for a list in redis.
         :param max_connection_pool_size: maximum number of connections in pool.
-        :param connection_kwargs: additional arguments for aio-redis ConnectionPool.
+            Each worker opens its own connection. Therefore this value has to be
+            at least number of workers + 1.
+        :param connection_kwargs: additional arguments for redis BlockingConnectionPool.
         """
         super().__init__(
             result_backend=result_backend,
             task_id_generator=task_id_generator,
         )
 
-        self.connection_pool: ConnectionPool = ConnectionPool.from_url(
+        self.connection_pool: ConnectionPool = BlockingConnectionPool.from_url(
             url=url,
             max_connections=max_connection_pool_size,
             **connection_kwargs,

--- a/taskiq_redis/schedule_source.py
+++ b/taskiq_redis/schedule_source.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from redis.asyncio import ConnectionPool, Redis, RedisCluster
+from redis.asyncio import BlockingConnectionPool, ConnectionPool, Redis, RedisCluster
 from taskiq import ScheduleSource
 from taskiq.abc.serializer import TaskiqSerializer
 from taskiq.compat import model_dump, model_validate
@@ -22,7 +22,7 @@ class RedisScheduleSource(ScheduleSource):
         This is how many keys will be fetched at once.
     :param max_connection_pool_size: maximum number of connections in pool.
     :param serializer: serializer for data.
-    :param connection_kwargs: additional arguments for aio-redis ConnectionPool.
+    :param connection_kwargs: additional arguments for redis BlockingConnectionPool.
     """
 
     def __init__(
@@ -35,7 +35,7 @@ class RedisScheduleSource(ScheduleSource):
         **connection_kwargs: Any,
     ) -> None:
         self.prefix = prefix
-        self.connection_pool: ConnectionPool = ConnectionPool.from_url(
+        self.connection_pool: ConnectionPool = BlockingConnectionPool.from_url(
             url=url,
             max_connections=max_connection_pool_size,
             **connection_kwargs,

--- a/tests/test_result_backend.py
+++ b/tests/test_result_backend.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 
 import pytest
@@ -129,6 +130,38 @@ async def test_keep_results_after_reading(redis_url: str) -> None:
     res1 = await result_backend.get_result(task_id=task_id)
     res2 = await result_backend.get_result(task_id=task_id)
     assert res1 == res2
+    await result_backend.shutdown()
+
+
+@pytest.mark.anyio
+async def test_set_result_max_connections(redis_url: str) -> None:
+    """
+    Tests that asynchronous backend works with connection limit.
+
+    :param redis_url: redis URL.
+    """
+    result_backend = RedisAsyncResultBackend(  # type: ignore
+        redis_url=redis_url,
+        max_connection_pool_size=1,
+        timeout=3,
+    )
+
+    task_id = uuid.uuid4().hex
+    result: "TaskiqResult[int]" = TaskiqResult(
+        is_err=True,
+        log="My Log",
+        return_value=11,
+        execution_time=112.2,
+    )
+    await result_backend.set_result(
+        task_id=task_id,
+        result=result,
+    )
+
+    async def get_result() -> None:
+        await result_backend.get_result(task_id=task_id, with_logs=True)
+
+    await asyncio.gather(*[get_result() for _ in range(10)])
     await result_backend.shutdown()
 
 

--- a/tests/test_schedule_source.py
+++ b/tests/test_schedule_source.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import uuid
 
@@ -106,6 +107,18 @@ async def test_buffer(redis_url: str) -> None:
     assert schedule1 in schedules
     assert schedule2 in schedules
     await source.shutdown()
+
+
+@pytest.mark.anyio
+async def test_max_connections(redis_url: str) -> None:
+    prefix = uuid.uuid4().hex
+    source = RedisScheduleSource(
+        redis_url,
+        prefix=prefix,
+        max_connection_pool_size=1,
+        timeout=3,
+    )
+    await asyncio.gather(*[source.get_schedules() for _ in range(10)])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #53.

I decided not to add `timeout` argument at the moment, because any unknown argument passed to constructor is passed to the `BlockedConnectionPool` (including `timeout` if user wishes to customize it).

`BlockingConnectionPool` default is 20 seconds. If you think it's too high, we can still customize that value without changing constructors themselves, like this:

```python
if "timeout" not in connection_kwargs:
    connection_kwargs["timeout"] = 3  # or other sensible default
```

## TODO

- [x] replace `ConnectionPool` with `BlockingConnectionPool`
- [x] add `connection_kwargs` (and max connections) to result backends
- [x] add tests
- [x] update documentation