### PR TITLE
fix #65: avoid worker crash in case connection is broken

### DIFF
--- a/taskiq_redis/redis_broker.py
+++ b/taskiq_redis/redis_broker.py
@@ -123,8 +123,12 @@ class ListQueueBroker(BaseRedisBroker):
         :yields: broker messages.
         """
         redis_brpop_data_position = 1
-        async with Redis(connection_pool=self.connection_pool) as redis_conn:
-            while True:
-                yield (await redis_conn.brpop(self.queue_name))[
-                    redis_brpop_data_position
-                ]
+        while True:
+            try:
+                async with Redis(connection_pool=self.connection_pool) as redis_conn:
+                    yield (await redis_conn.brpop(self.queue_name))[
+                        redis_brpop_data_position
+                    ]
+            except ConnectionError as exc:
+                logger.warning("Redis connection error: %s", exc)
+                continue


### PR DESCRIPTION
The issue is that if the connection is disrupted (due to a Redis restart or temporary connectivity issues), the Taskiq worker crashes, interrupting all ongoing handlers. For example, any long-running tasks will be interrupted and will not complete their work.