### PR TITLE
feat: Add get_progress and set_progress to redis result backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: black
         name: Format with Black
-        entry: black
+        entry: poetry run black
         language: system
         types: [python]
 
@@ -36,6 +36,6 @@ repos:
 
       - id: mypy
         name: Validate types with MyPy
-        entry: mypy
+        entry: poetry run mypy
         language: system
         types: [ python ]


### PR DESCRIPTION
Uses as standard suffix on the redis key (hardcoded as "__progress") to store progress results.