### PR TITLE
fix: ack to the right stream in case of dynamic queue name

### DIFF
--- a/taskiq_redis/redis_cluster_broker.py
+++ b/taskiq_redis/redis_cluster_broker.py
@@ -171,10 +171,10 @@ class RedisStreamClusterBroker(BaseRedisClusterBroker):
             approximate=self.approximate,
         )
 
-    def _ack_generator(self, id: str) -> Callable[[], Awaitable[None]]:
+    def _ack_generator(self, id: str, queue_name: str) -> Callable[[], Awaitable[None]]:
         async def _ack() -> None:
             await self.redis.xack(
-                self.queue_name,
+                queue_name,
                 self.consumer_group_name,
                 id,
             )
@@ -194,10 +194,10 @@ class RedisStreamClusterBroker(BaseRedisClusterBroker):
                 block=self.block,
                 noack=False,
             )
-            for _, msg_list in fetched:
+            for stream, msg_list in fetched:
                 for msg_id, msg in msg_list:
                     logger.debug("Received message: %s", msg)
                     yield AckableMessage(
                         data=msg[b"data"],
-                        ack=self._ack_generator(msg_id),
+                        ack=self._ack_generator(id=msg_id, queue_name=stream),
                     )


### PR DESCRIPTION
Due to #94 and #100 , the ack for `StreamBroker` is wrong as it does not take into account the dynamic queue name and always ack on the "main" queue.

This PR fix that issue.