### PR TITLE
feat: update bitnami catalog to legacy version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: bitnami/redis:7.4.2
+    image: bitnamilegacy/redis:7.4.2
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
     healthcheck:
@@ -12,7 +12,7 @@ services:
     ports:
       - 7000:6379
   redis-node-0: &redis-node
-    image: docker.io/bitnami/redis-cluster:7.4.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4.2
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
       REDIS_NODES: "redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5"
@@ -36,7 +36,7 @@ services:
     <<: *redis-node
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:7.4.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4.2
     depends_on:
       - redis-node-0
       - redis-node-1
@@ -58,7 +58,7 @@ services:
       - 7001:6379
 
   redis-master:
-    image: bitnami/redis:7.4.2
+    image: bitnamilegacy/redis:7.4.2
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
     healthcheck:
@@ -69,7 +69,7 @@ services:
       start_period: 10s
 
   redis-sentinel:
-    image: bitnami/redis-sentinel:7.4.2
+    image: bitnamilegacy/redis-sentinel:7.4.2
     depends_on:
       - redis-master
     environment:


### PR DESCRIPTION
bitnami moved all these images to bitnamilegacy catalog, so the image names were updated
(https://hub.docker.com/r/bitnami/redis)