### PR TITLE
Fixed race-condition for streambroker.

### DIFF
--- a/taskiq_redis/redis_broker.py
+++ b/taskiq_redis/redis_broker.py
@@ -295,28 +295,31 @@ class RedisStreamBroker(BaseRedisBroker):
                         )
                 logger.debug("Starting fetching unacknowledged messages")
                 for stream in [self.queue_name, *self.additional_streams.keys()]:
-                    lock = redis_conn.lock(
+                    pipe = redis_conn.pipeline()
+                    lock = pipe.lock(
                         f"autoclaim:{self.consumer_group_name}:{stream}",
                         timeout=self.unacknowledged_lock_timeout,
                     )
-                    if await lock.locked():
-                        continue
-                    async with lock:
-                        pending = await redis_conn.xautoclaim(
-                            name=stream,
-                            groupname=self.consumer_group_name,
-                            consumername=self.consumer_name,
-                            min_idle_time=self.idle_timeout,
-                            count=self.unacknowledged_batch_size,
+                    await lock.acquire()
+                    await pipe.xautoclaim(
+                        name=stream,
+                        groupname=self.consumer_group_name,
+                        consumername=self.consumer_name,
+                        min_idle_time=self.idle_timeout,
+                        count=self.unacknowledged_batch_size,
+                    )
+                    await lock.release()
+                    results = await pipe.execute()
+                    pending = results[1]
+
+                    logger.debug(
+                        "Found %d pending messages in stream %s",
+                        len(pending[1]),
+                        stream,
+                    )
+                    for msg_id, msg in pending[1]:
+                        logger.debug("Received message: %s", msg)
+                        yield AckableMessage(
+                            data=msg[b"data"],
+                            ack=self._ack_generator(id=msg_id, queue_name=stream),
                         )
-                        logger.debug(
-                            "Found %d pending messages in stream %s",
-                            len(pending[1]),
-                            stream,
-                        )
-                        for msg_id, msg in pending[1]:
-                            logger.debug("Received message: %s", msg)
-                            yield AckableMessage(
-                                data=msg[b"data"],
-                                ack=self._ack_generator(id=msg_id, queue_name=stream),
-                            )


### PR DESCRIPTION
This PR fixes #123 .

I tried multiple approaches and found this one working. 

<details>
<summary>Details</summary>

```python
import asyncio

import redis.asyncio as aioredis

STREAM, GROUP = "taskiq_bug", "taskiq"


async def setup():
    r = await aioredis.from_url("redis://localhost:6379")
    await r.delete(STREAM)
    await r.xgroup_create(STREAM, GROUP, id="0", mkstream=True)
    msg_id = await r.xadd(STREAM, {"data": b"test"})
    await r.xreadgroup(GROUP, "worker-seed", {STREAM: ">"}, count=1)
    await r.aclose()
    return msg_id


async def worker(name: str):
    conn = await aioredis.from_url("redis://localhost:6379")
    lock_key = f"autoclaim:{GROUP}:{STREAM}"

    pipe = conn.pipeline()
    lock = pipe.lock(lock_key)
    await lock.acquire()
    pipe.xautoclaim(
        STREAM,
        GROUP,
        name,
        min_idle_time=100,
        count=10,
    )
    await lock.release()
    res = await pipe.execute()
    if res[1][1]:
        msgs = res[1][1]
        print(name, "got", msgs[0][0])

    await conn.aclose()


async def run_once():
    await setup()
    await asyncio.sleep(0.2)
    await asyncio.gather(
        worker("worker-0"),
        worker("worker-1"),
    )


async def main():
    for _ in range(25):
        await run_once()


if __name__ == "__main__":
    asyncio.run(main())
```

Output: 

```
worker-0 got b'1782170479725-0'
worker-1 got b'1782170479929-0'
worker-0 got b'1782170480133-0'
worker-0 got b'1782170480337-0'
worker-0 got b'1782170480540-0'
worker-0 got b'1782170480744-0'
worker-0 got b'1782170480947-0'
worker-0 got b'1782170481150-0'
worker-0 got b'1782170481354-0'
worker-0 got b'1782170481557-0'
worker-0 got b'1782170481760-0'
worker-0 got b'1782170481963-0'
worker-0 got b'1782170482166-0'
worker-0 got b'1782170482369-0'
worker-1 got b'1782170482572-0'
worker-1 got b'1782170482775-0'
worker-0 got b'1782170482978-0'
worker-0 got b'1782170483180-0'
worker-0 got b'1782170483383-0'
worker-0 got b'1782170483586-0'
worker-0 got b'1782170483790-0'
worker-1 got b'1782170483993-0'
worker-0 got b'1782170484197-0'
worker-0 got b'1782170484402-0'
worker-0 got b'1782170484605-0'
```

Here's redis monitor output:

```
1782169992.799451 [0 172.19.0.1:37304] "MULTI"
1782169992.799458 [0 172.19.0.1:37304] "SET" "autoclaim:taskiq:taskiq_bug" "f1015f306e8f11f1ac1603adb8b6c235" "NX"
1782169992.799472 [0 172.19.0.1:37304] "XAUTOCLAIM" "taskiq_bug" "taskiq" "worker-0" "100" "0-0" "COUNT" "10"
1782169992.799474 [0 172.19.0.1:37304] "EVALSHA" "c3f8721cbb97f72bc19e972846bd7aaf91901658" "1" "autoclaim:taskiq:taskiq_bug" "f1015f306e8f11f1ac1603adb8b6c235"
1782169992.799487 [0 lua] "get" "autoclaim:taskiq:taskiq_bug"
1782169992.799491 [0 lua] "del" "autoclaim:taskiq:taskiq_bug"
1782169992.799494 [0 172.19.0.1:37304] "EXEC"
1782169992.799503 [0 172.19.0.1:37316] "MULTI"
1782169992.799506 [0 172.19.0.1:37316] "SET" "autoclaim:taskiq:taskiq_bug" "f1017c546e8f11f1ac1603adb8b6c235" "NX"
1782169992.799509 [0 172.19.0.1:37316] "XAUTOCLAIM" "taskiq_bug" "taskiq" "worker-1" "100" "0-0" "COUNT" "10"
1782169992.799510 [0 172.19.0.1:37316] "EVALSHA" "c3f8721cbb97f72bc19e972846bd7aaf91901658" "1" "autoclaim:taskiq:taskiq_bug" "f1017c546e8f11f1ac1603adb8b6c235"
1782169992.799513 [0 lua] "get" "autoclaim:taskiq:taskiq_bug"
1782169992.799514 [0 lua] "del" "autoclaim:taskiq:taskiq_bug"
1782169992.799515 [0 172.19.0.1:37316] "EXEC"
```

</details>

It seems to do exactly what is needed. 